### PR TITLE
Fix 'DigitalPin' compilation error in ws2812b extension

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,16 @@
 namespace ws2812b {
     //% shim=sendBufferAsm
-    export function sendBuffer(buf: Buffer, pin: DigitalPin) {
+    /**
+     * Sends a color buffer to a light strip
+     */
+    export function sendBuffer(buf: Buffer, pin: number) {
     }
 
     //% shim=setBufferMode
-    export function setBufferMode(pin: DigitalPin, mode: number) {
+    /**
+     * Sets the buffer mode
+     */
+    export function setBufferMode(pin: number, mode: number) {
 
     }
 

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "ws2812b",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A driver for WS2812B programmable LEDs in MakeCode",
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
Fixed the compilation error `TS2304: Cannot find name 'DigitalPin'` by using the more generic `number` type for pin parameters in `main.ts`. This ensures the `ws2812b` extension is compatible across different PXT targets that might not define `DigitalPin` globally. The package version was also bumped to `0.1.3` and the repository was cleaned of unnecessary build artifacts.

Fixes #3

---
*PR created automatically by Jules for task [13776372928650109085](https://jules.google.com/task/13776372928650109085) started by @chatelao*